### PR TITLE
moov atom faststart

### DIFF
--- a/lib/process-video-conversion.js
+++ b/lib/process-video-conversion.js
@@ -26,7 +26,7 @@ function processVideoConversion(sourceFilePath, targetFilePath) {
         throw err;
     }
 
-    const command = `"${ffmpegInstallationList[0]}" -hide_banner -i "${sourceFilePath}" -y -crf 17 "${targetFilePath}"`;
+    const command = `"${ffmpegInstallationList[0]}" -hide_banner -i "${sourceFilePath}" -y -crf 17 -movflags +faststart "${targetFilePath}"`;
 
     const childInfo = cp.spawnSync(command, {
         stdio: "ignore",


### PR DESCRIPTION
Adding '-movflags +faststart'
This relocates the 'moov' atom from end to beginning of the MP4 output file. Otherwise the file will have to be completely downloaded before it can begin playback.